### PR TITLE
Security: avoid to display private keys at start

### DIFF
--- a/iguana/iguana_wallet.c
+++ b/iguana/iguana_wallet.c
@@ -1428,6 +1428,7 @@ TWOSTRINGS_AND_INT(bitcoinrpc,walletpassphrase,password,permanentfile,timeout)
         privkey = jumblr_privkey(myinfo,coinaddr,0,KMDaddr,"btc ");
         smartaddress_add(myinfo,privkey,"btc","KMD",0.,0.);
     }
+    strcpy(retstr, "walletpassphrase call finished"); // TODO: Enhancement: replace each private key with *** except few first and last characters
     return(retstr);
 }
 


### PR DESCRIPTION
When wp_7776 / wp_7779 is launched, walletpassphrase will call SuperNET_login that return all private keys dumped in the screen, it can appear in logs if "iguana TV" output are directed to a log file as many operators are doing.

As displaying the private keys is not necessary to make iguana running fine, we can hide private keys. Good security practice recommand to have no Clear text password in trace logs:
https://glossary.pro2col.com/clear-text-password/
https://www.bleepingcomputer.com/news/security/twitter-admits-recording-plaintext-passwords-in-internal-logs-just-like-github/

This change was successfully tested on phm87_SH 3P.

To enhance this PR, it is possible to replace private keys in the json by * except few first and last characters.