### PR TITLE
Add provisions for early season grace period.

### DIFF
--- a/doc/bible.md
+++ b/doc/bible.md
@@ -256,6 +256,8 @@ In the previous Notary Node seasons, there were no protocolled rules or policies
 
 We reconsidered this part and decided to author and publish these transparent guidelines which we call the “Notary Node Bible”. The Komodo team also decided that a violation of any of the above [rules](#responsibilities-rights-and-duties-of-a-nn) will lead to immediate loss of the NN spot. In the event that a single individual has a second violation in the following season, it would lead to disqualification from all future elections and seasons. 
 
+A "grace period" at the beginning of Season 4 will apply until September 1st 2020, to allow for adjustment to rules based on the framework established in this document, and to give new notaries time to make mistakes, learn and tweak their servers. During this time, minor infractions may lead to "probationary status" with Gurus and the NN community assisting non-conforming operators achieve stable and productive participation. Major infractions (i.e. grossly negligent or malicious activity) will be suject to harsher penalty up to and including spot-loss / disqualification.
+
 In case of such a spot-loss or disqualification, the next candidate from the election results will be eligible for the spot and the pubkey would be replaced with the next scheduled hardfork update. 
 
 ### NN season


### PR DESCRIPTION
This should give time for rule clarity and tweaking of processes etc to avoid unintended mass culling of the NN group while initial rule-sets are scrutinized, adapted and more explicitly defined with respect to actual conditions within the network.

For example - `Reach at least 33% of your region’s best monthly NN notarization score. This is checked on the first day of each month, beginning one month after the new NN season has begun.` has been tagged for review due to early notarisation figures indicating skewed distribution (e.g. in SH region, #1 node has 2x score of #2 node)

I'd encourage NN ops to discuss a revised metric and submit it in accordance with the "polls and voting" section of the NN bible.