### PR TITLE
remove duplicate iguana login

### DIFF
--- a/iguana/iguana_wallet.c
+++ b/iguana/iguana_wallet.c
@@ -1390,7 +1390,6 @@ TWOSTRINGS_AND_INT(bitcoinrpc,walletpassphrase,password,permanentfile,timeout)
         strcpy(myinfo->permanentfile,permanentfile);
     if ( (retstr= SuperNET_login(IGUANA_CALLARGS,myinfo->handle,myinfo->secret,myinfo->permanentfile,myinfo->password)) != 0 )
         free(retstr);
-    retstr = SuperNET_login(IGUANA_CALLARGS,myinfo->handle,myinfo->secret,myinfo->permanentfile,myinfo->password);
     myinfo->expiration = (uint32_t)time(NULL) + timeout;
     iguana_walletinitcheck(myinfo,coin);
     if ( coin != 0 )


### PR DESCRIPTION
Not tested enough, to test more !

If the second iguana login fails, memory is not free (compared to the first login where it is handled).
If the second try to login is needed, it can be moved within the if statement of the first login.