### PR TITLE
[Log enhancement] Spent utxo detection from Labs

### DIFF
--- a/iguana/dpow/dpow_network.c
+++ b/iguana/dpow/dpow_network.c
@@ -2007,6 +2007,10 @@ void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,stru
         if ( (bp->recvmask & (1LL << senderind)) == 0 )
         {
             printf("%s",printstr);
+	    FILE * fptr;
+            fptr = fopen("spent_utxos", "a+");
+            fprintf(fptr, "%s",printstr);
+            fclose(fptr);
 	}
         if ( bestmask != 0 )
             bp->notaries[senderind].bestmask = bestmask;

--- a/iguana/dpow/dpow_network.c
+++ b/iguana/dpow/dpow_network.c
@@ -1991,7 +1991,9 @@ void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,stru
                 bp->notaries[senderind].src.prev_vout = srcvout;
                 //char str[65]; printf("%s senderind.%d <- %s/v%d\n",dp->symbol,senderind,bits256_str(str,srcutxo),srcvout);
             }
-	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,bp->srccoin->symbol,Notaries_elected[senderind][0],bits256_str(str,srcutxo),srcvout);
+	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,bp->srccoin->symbol,Notaries_elected[senderind][0],bits256_str(str,srcutxo),srcvout); // the else clause is impossible to be reached so this log won't ever be printer
+	    
+	    // Source: https://github.com/KMDLabs/SuperNET/blob/blackjok3r/iguana/dpow/dpow_network.c#L1989
 	    if ( (tmpjson= dpow_gettxout(myinfo, bp->srccoin, srcutxo, srcvout)) == 0 )
 	        sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,bp->srccoin->symbol,Notaries_elected[senderind][0],bits256_str(str,srcutxo),srcvout);
 	    else {
@@ -2004,7 +2006,9 @@ void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,stru
                 bp->notaries[senderind].dest.prev_hash = destutxo;
                 bp->notaries[senderind].dest.prev_vout = destvout;
             }
-	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,dp->dest,Notaries_elected[senderind][0],bits256_str(str,destutxo),destvout);
+	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,dp->dest,Notaries_elected[senderind][0],bits256_str(str,destutxo),destvout); // the else clause is impossible to be reached so this log won't ever be printer
+
+	    // Source: https://github.com/KMDLabs/SuperNET/blob/blackjok3r/iguana/dpow/dpow_network.c#L1989
 	    if ( (tmpjson= dpow_gettxout(myinfo, bp->destcoin, destutxo, destvout)) == 0 )
 	        sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,dp->dest,Notaries_elected[senderind][0],bits256_str(str,destutxo),destvout);
 	    else {
@@ -2017,11 +2021,13 @@ void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,stru
             bp->notaries[bp->myind].src.prev_hash = bp->mysrcutxo;
             bp->notaries[bp->myind].dest.prev_hash = bp->mydestutxo;
         }
+
+	// Source: https://github.com/KMDLabs/SuperNET/blob/blackjok3r/iguana/dpow/dpow_network.c#L2016
         if ( (tmpjson= dpow_gettxout(myinfo, bp->srccoin, srcutxo, srcvout)) == 0 || (tmpjson= dpow_gettxout(myinfo, bp->destcoin, destutxo, destvout)) == 0 )
         {
             printf("%s",printstr);
 	    FILE * fptr;
-            fptr = fopen("spent_utxos", "a+");
+            fptr = fopen("spent_utxos", "a+"); // this log file will keep growing, TODO: add log rotate
             fprintf(fptr, "%s",printstr);
             fclose(fptr);
 	}

--- a/iguana/dpow/dpow_network.c
+++ b/iguana/dpow/dpow_network.c
@@ -1978,7 +1978,7 @@ void dpow_ratify_update(struct supernet_info *myinfo,struct dpow_info *dp,struct
 
 void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,struct dpow_block *bp,uint8_t senderind,int8_t bestk,uint64_t bestmask,uint64_t recvmask,bits256 srcutxo,uint16_t srcvout,bits256 destutxo,uint16_t destvout,uint8_t siglens[2],uint8_t sigs[2][DPOW_MAXSIGLEN],uint32_t paxwdcrc)
 {
-    bits256 srchash; uint32_t now; int32_t i,flag,bestmatches = 0,matches = 0,paxmatches = 0,paxbestmatches = 0;
+    bits256 srchash; uint32_t now; int32_t i,flag,bestmatches = 0,matches = 0,paxmatches = 0,paxbestmatches = 0; char str[65],printstr[65536];
     if ( bp->myind < 0 )
         return;
     if ( bp->isratify == 0 && bp->state != 0xffffffff && senderind >= 0 && senderind < bp->numnotaries && bits256_nonz(srcutxo) != 0 && bits256_nonz(destutxo) != 0 )
@@ -1991,17 +1991,23 @@ void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,stru
                 bp->notaries[senderind].src.prev_vout = srcvout;
                 //char str[65]; printf("%s senderind.%d <- %s/v%d\n",dp->symbol,senderind,bits256_str(str,srcutxo),srcvout);
             }
+	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,bp->srccoin->symbol,Notaries_elected[senderind][0],bits256_str(str,srcutxo),srcvout);
             if ( bits256_nonz(destutxo) != 0 )
             {
                 bp->notaries[senderind].dest.prev_hash = destutxo;
                 bp->notaries[senderind].dest.prev_vout = destvout;
             }
+	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,dp->dest,Notaries_elected[senderind][0],bits256_str(str,destutxo),destvout);
         }
         else
         {
             bp->notaries[bp->myind].src.prev_hash = bp->mysrcutxo;
             bp->notaries[bp->myind].dest.prev_hash = bp->mydestutxo;
         }
+        if ( (bp->recvmask & (1LL << senderind)) == 0 )
+        {
+            printf("%s",printstr);
+	}
         if ( bestmask != 0 )
             bp->notaries[senderind].bestmask = bestmask;
         if ( recvmask != 0 )

--- a/iguana/dpow/dpow_network.c
+++ b/iguana/dpow/dpow_network.c
@@ -1978,33 +1978,46 @@ void dpow_ratify_update(struct supernet_info *myinfo,struct dpow_info *dp,struct
 
 void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,struct dpow_block *bp,uint8_t senderind,int8_t bestk,uint64_t bestmask,uint64_t recvmask,bits256 srcutxo,uint16_t srcvout,bits256 destutxo,uint16_t destvout,uint8_t siglens[2],uint8_t sigs[2][DPOW_MAXSIGLEN],uint32_t paxwdcrc)
 {
-    bits256 srchash; uint32_t now; int32_t i,flag,bestmatches = 0,matches = 0,paxmatches = 0,paxbestmatches = 0; char str[65],printstr[65536];
+    bits256 srchash; uint32_t now; int32_t i,flag,bestmatches = 0,matches = 0,paxmatches = 0,paxbestmatches = 0; cJSON* tmpjson = 0; char str[65],printstr[65536];
     if ( bp->myind < 0 )
         return;
     if ( bp->isratify == 0 && bp->state != 0xffffffff && senderind >= 0 && senderind < bp->numnotaries && bits256_nonz(srcutxo) != 0 && bits256_nonz(destutxo) != 0 )
     {
         if ( bp->myind != senderind )
         {
-            if ( bits256_nonz(srcutxo) != 0 )
+            if ( bits256_nonz(srcutxo) != 0 ) // this will be always true because this is contained inside a if at line 1984 with this condition
             {
                 bp->notaries[senderind].src.prev_hash = srcutxo;
                 bp->notaries[senderind].src.prev_vout = srcvout;
                 //char str[65]; printf("%s senderind.%d <- %s/v%d\n",dp->symbol,senderind,bits256_str(str,srcutxo),srcvout);
             }
 	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,bp->srccoin->symbol,Notaries_elected[senderind][0],bits256_str(str,srcutxo),srcvout);
-            if ( bits256_nonz(destutxo) != 0 )
+	    if ( (tmpjson= dpow_gettxout(myinfo, bp->srccoin, srcutxo, srcvout)) == 0 )
+	        sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,bp->srccoin->symbol,Notaries_elected[senderind][0],bits256_str(str,srcutxo),srcvout);
+	    else {
+		free_json(tmpjson);
+                tmpjson = 0;
+	    }
+	
+            if ( bits256_nonz(destutxo) != 0 ) // this will be always true because this is contained inside a if at line 1984 with this condition
             {
                 bp->notaries[senderind].dest.prev_hash = destutxo;
                 bp->notaries[senderind].dest.prev_vout = destvout;
             }
 	    else sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,dp->dest,Notaries_elected[senderind][0],bits256_str(str,destutxo),destvout);
+	    if ( (tmpjson= dpow_gettxout(myinfo, bp->destcoin, destutxo, destvout)) == 0 )
+	        sprintf(printstr,MAGENTA"[%s:%i]: coin.(%s) node.(%s) txid.(%s) v.(%i) is spent\n"RESET,bp->srccoin->symbol,bp->height,dp->dest,Notaries_elected[senderind][0],bits256_str(str,destutxo),destvout);
+	    else {
+		free_json(tmpjson);
+                tmpjson = 0;
+	    }
         }
         else
         {
             bp->notaries[bp->myind].src.prev_hash = bp->mysrcutxo;
             bp->notaries[bp->myind].dest.prev_hash = bp->mydestutxo;
         }
-        if ( (bp->recvmask & (1LL << senderind)) == 0 )
+        if ( (tmpjson= dpow_gettxout(myinfo, bp->srccoin, srcutxo, srcvout)) == 0 || (tmpjson= dpow_gettxout(myinfo, bp->destcoin, destutxo, destvout)) == 0 )
         {
             printf("%s",printstr);
 	    FILE * fptr;
@@ -2012,6 +2025,9 @@ void dpow_notarize_update(struct supernet_info *myinfo,struct dpow_info *dp,stru
             fprintf(fptr, "%s",printstr);
             fclose(fptr);
 	}
+	free_json(tmpjson);
+        tmpjson = 0;
+	
         if ( bestmask != 0 )
             bp->notaries[senderind].bestmask = bestmask;
         if ( recvmask != 0 )


### PR DESCRIPTION
**DO NOT MERGE yet**, this PR aims to provoke discussions, tests and analysis. I think that a part may be missing because I have way too much notaries flagged as using spent utxos.

Labs iguana displays a log when a notary is trying to use a spent utxo:
https://github.com/KMDLabs/SuperNET/blob/blackjok3r/iguana/dpow/dpow_network.c#L1997

Labs iguana also contains huge changes (consensus changes in my opinion) in this part of the code. This PR doesn't change any consensus or calculations, it performs another calculation/check that I copy pasted from Labs. I think that maybe there is another part to copy so this PR may be incomplete.

Main iguana contains conditions that will be always true, it was changed in iguana (see comment below).

Can we discuss, analyse and code review this change then merge it into dev branch and allow some motivated notaries to run the dev branch?


``` 
   if ( bp->isratify == 0 && bp->state != 0xffffffff && senderind >= 0 && senderind < bp->numnotaries && bits256_nonz(srcutxo) != 0 && bits256_nonz(destutxo) != 0 )
    {
        if ( bp->myind != senderind )
        {
            if ( bits256_nonz(srcutxo) != 0 ) // this will be always true because this is contained inside a if at line 1984 with this condition
            {
 ```

To compare with Labs'code (link here above).


**How to verify if this log is correct?**

1) Compare against komodo log (line to uncomment and rebuild):
https://github.com/KomodoPlatform/komodo/blob/666047b4f56778927a1787a8743fbb4bbede6068/src/main.cpp#L1935
LogPrintf("Missing inputs: %s.%d", txin.prevout.hash.ToString(), txin.prevout.n);

2) Another interesting possibility to check against (thank you Alright):
https://discord.com/channels/412898016371015680/456828345871761408/650472009222062102
``` 
#!/usr/bin/env python3
import sys
import json
import stakerlib
from slickrpc import Proxy
import requests

rpc = stakerlib.def_credentials('KMD')

HEEX = sys.argv[1]

decode = rpc.decoderawtransaction(HEEX)

for i in decode['vin']:
    print('\n')
    r = requests.get('http://kmd.explorer.dexstats.info/insight-api-komodo/tx/' + i['txid'] + '/')
    r = r.json()
    print(r['vout'][i['vout']])
    if 'spentTxId' in r['vout'][i['vout']]:
        print(r['vout'][i['vout']]['scriptPubKey']['addresses'][0] + ': ' + str(r['txid']) + ' vout:' + `str(i['vout']))
 ```

https://github.com/KMDLabs/pos64staker/blob/master/stakerlib.py