### PR TITLE
Create scoring_epochs.json

### DIFF
--- a/doc/scoring_epochs.json
+++ b/doc/scoring_epochs.json
@@ -1,32 +1,48 @@
 {
-    "Season_4": {
-        "Main": {
-            "RFOX": {
-                "end_time":1613856136      # Fri Feb 19 22:22:16 2021 +0100 commit 1c3d3cd06fd2cacc4112c5165d20e9e9fa4dadf0 + 24hr
-            },
-            "PGT": {
-                "end_time":1616337330      # Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr
-            },
-            "STBL": {
-                "end_time":1616337330      # Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr
-            },
-            "GLEEC": {
-                "start_time":1617095376    # Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f
-            }
-        },
-        "Third_Party": {
-            "PBC": {
-                "start_time":1606390840    # Wed Nov 25 12:40:40 2020 +0100 commit 774d6aaba0f1ad78f8cf4f6a6591ecd344ff1a60
-            },
-            "HUSH3": {
-                "start_time":1593331689,   # Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb
-                "end_time":1603710234      # Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3 + 24hr
-            },
-            "GLEEC": {
-                "start_time":1603623834    # Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3
-            },
-            "MCL": {
-                "start_time":1593331689    # Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb
-            }, 
-        }
-    }
+	"Season_4": {
+		"season_start": 1592146800,
+		"season_start_comment": "https://github.com/KomodoPlatform/komodo/blob/master/src/komodo_globals.h#L47",
+		"season_end": 1617364800,
+		"season_end_comment": "April 2nd 2021 12pm GMT https://github.com/KomodoPlatform/dPoW/commit/24b45ea5e61098fe221d2b68560778fcc72952aa#diff-ef72250c1397f6c2f24aa881988b3fe8d2d9edf7b338e9889321fa91f5c1c9acR187",
+		"Servers": {
+			"dPoW-Mainnet": {
+				"RFOX": {
+					"end_time": 1613856136,
+					"end_time_comment": "Fri Feb 19 22:22:16 2021 +0100 commit 1c3d3cd06fd2cacc4112c5165d20e9e9fa4dadf0 + 24hr"
+				},
+				"PGT": {
+					"end_time": 1616337330,
+					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr"
+				},
+				"STBL": {
+					"end_time": 1616337330,
+					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr"
+				},
+				"GLEEC": {
+					"start_time": 1617095376,
+					"start_time_comment": "Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f"
+				}
+			},
+			"dPoW-3P": {
+				"PBC": {
+					"start_time": 1606390840,
+					"start_time_comment": "Wed Nov 25 12:40:40 2020 +0100 commit 774d6aaba0f1ad78f8cf4f6a6591ecd344ff1a60"
+				},
+				"HUSH3": {
+					"start_time": 1593331689,
+					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb",
+					"end_time": 1603710234,
+					"end_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3 + 24hr"
+				},
+				"GLEEC": {
+					"start_time": 1603623834,
+					"end_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3"
+				},
+				"MCL": {
+					"start_time": 1593331689,
+					"end_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb"
+				}
+			}
+		}
+	}
+}

--- a/doc/scoring_epochs.json
+++ b/doc/scoring_epochs.json
@@ -19,28 +19,28 @@
 					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0"
 				},
 				"GLEEC": {
-					"start_time": 1617095376,
-					"start_time_comment": "Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f"
+					"start_time": 1617181776,
+					"start_time_comment": "Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f +24hrs"
 				}
 			},
 			"dPoW-3P": {
 				"PBC": {
 					"start_time": 1606390840,
-					"start_time_comment": "Wed Nov 25 12:40:40 2020 +0100 commit 774d6aaba0f1ad78f8cf4f6a6591ecd344ff1a60"
+					"start_time_comment": "Wed Nov 25 12:40:40 2020 +0100 commit 774d6aaba0f1ad78f8cf4f6a6591ecd344ff1a60 +24hrs"
 				},
 				"HUSH3": {
 					"start_time": 1593331689,
-					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb",
-					"end_time": 1603710234,
+					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb +24hrs",
+					"end_time": 1603623834,
 					"end_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3"
 				},
 				"GLEEC": {
-					"start_time": 1603623834,
-					"start_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3"
+					"start_time": 1603710234,
+					"start_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3 +24hrs"
 				},
 				"MCL": {
 					"start_time": 1593331689,
-					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb"
+					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb +24hrs"
 				}
 			}
 		}

--- a/doc/scoring_epochs.json
+++ b/doc/scoring_epochs.json
@@ -7,16 +7,16 @@
 		"Servers": {
 			"dPoW-Mainnet": {
 				"RFOX": {
-					"end_time": 1613856136,
-					"end_time_comment": "Fri Feb 19 22:22:16 2021 +0100 commit 1c3d3cd06fd2cacc4112c5165d20e9e9fa4dadf0 + 24hr"
+					"end_time": 1613769736,
+					"end_time_comment": "Fri Feb 19 22:22:16 2021 +0100 commit 1c3d3cd06fd2cacc4112c5165d20e9e9fa4dadf0"
 				},
 				"PGT": {
-					"end_time": 1616337330,
-					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr"
+					"end_time": 1616250930,
+					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0"
 				},
 				"STBL": {
-					"end_time": 1616337330,
-					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr"
+					"end_time": 1616250930,
+					"end_time_comment": "Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0"
 				},
 				"GLEEC": {
 					"start_time": 1617095376,
@@ -32,15 +32,15 @@
 					"start_time": 1593331689,
 					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb",
 					"end_time": 1603710234,
-					"end_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3 + 24hr"
+					"end_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3"
 				},
 				"GLEEC": {
 					"start_time": 1603623834,
-					"end_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3"
+					"start_time_comment": "Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3"
 				},
 				"MCL": {
 					"start_time": 1593331689,
-					"end_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb"
+					"start_time_comment": "Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb"
 				}
 			}
 		}

--- a/doc/scoring_epochs.json
+++ b/doc/scoring_epochs.json
@@ -1,0 +1,32 @@
+{
+    "Season_4": {
+        "Main": {
+            "RFOX": {
+                "end_time":1613856136      # Fri Feb 19 22:22:16 2021 +0100 commit 1c3d3cd06fd2cacc4112c5165d20e9e9fa4dadf0 + 24hr
+            },
+            "PGT": {
+                "end_time":1616337330      # Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr
+            },
+            "STBL": {
+                "end_time":1616337330      # Sat Mar 20 15:35:30 2021 +0100 commit b70d11a3f356ab2aa7925ba6307a5397ab9623a0 + 24hr
+            },
+            "GLEEC": {
+                "start_time":1617095376    # Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f
+            }
+        },
+        "Third_Party": {
+            "PBC": {
+                "start_time":1606390840    # Wed Nov 25 12:40:40 2020 +0100 commit 774d6aaba0f1ad78f8cf4f6a6591ecd344ff1a60
+            },
+            "HUSH3": {
+                "start_time":1593331689,   # Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb
+                "end_time":1603710234      # Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3 + 24hr
+            },
+            "GLEEC": {
+                "start_time":1603623834    # Sun Oct 25 12:03:54 2020 +0100 commit 3efe36aa528495223633a560c7d457a31b3a94c3
+            },
+            "MCL": {
+                "start_time":1593331689    # Sat Jun 27 10:08:09 2020 +0200 commit 09bbc0055be462ad53dbe2c0af2d7202a9c362eb
+            }, 
+        }
+    }

--- a/doc/scoring_epochs.json
+++ b/doc/scoring_epochs.json
@@ -21,6 +21,10 @@
 				"GLEEC": {
 					"start_time": 1617181776,
 					"start_time_comment": "Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f +24hrs"
+				},
+				"VOTE2021": {
+					"start_time": 1617181776,
+					"start_time_comment": "Tue Mar 30 17:09:36 2021 +0800 commit 677700939d5711286f69e1c9bb438ad05782230f +24hrs"
 				}
 			},
 			"dPoW-3P": {


### PR DESCRIPTION
To simplify scoring calculation, I'd like to maintain this json file to define the timestamps for when to start / stop applying scores for notarisations.
Each timestamp relates to the UNIX epoch time of the relevant commit hash of the merge into master branch when a coin was added or removed from dPoW as noted in an updateXXX.md file. 

For coins being added, the timestamp of the commit is used. Notaries should be aware of an pending change if subscribed to this repo as per https://github.com/KomodoPlatform/dPoW/blob/dev/doc/bible.md#nn-duties section iv. The earliest to update and add new coins will benefit from bonus notarisation points for their rapid response.

For coins being removed, an additional 24 hours is proposed as per section iv. `react in a timely manner (<24h)`  so the timestamp is commit hash epoch time + 24hrs.