### PR TITLE
Fix typo in port num for block9 & hsukrd

### DIFF
--- a/iguana/m_notary_testnet2021
+++ b/iguana/m_notary_testnet2021
@@ -32,8 +32,8 @@ curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"ad
 curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"199.247.6.203\"}"   # rustytwilight
 curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"34.64.219.8\"}"  #dathbezumniy
 curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"135.181.219.27\"}"  #dathbezumniy
-curl --url "http://127.0.0.1:7778" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"139.99.134.200\"}"   # hsukrd
-curl --url "http://127.0.0.1:7778" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"135.125.233.86\"}"  # block9
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"139.99.134.200\"}"   # hsukrd
+curl --url "http://127.0.0.1:7776" --data "{\"agent\":\"iguana\",\"method\":\"addnotary\",\"ipaddr\":\"135.125.233.86\"}"  # block9
 
 # add LTC
 curl --url "http://127.0.0.1:7776" --data "{\"conf\":\"litecoin.conf\",\"path\":\"${HOME#"/"}/.litecoin\",\"prefetchlag\":-1,\"poll\":1,\"active\":1,\"agent\":\"iguana\",\"method\":\"addcoin\",\"newcoin\":\"LTC\",\"startpend\":64,\"endpend\":64,\"services\":0,\"maxpeers\":512,\"RELAY\":-1,\"VALIDATE\":0,\"portp2p\":10111,\"minconfirms\":1,\"name\":\"litecoin\",\"netmagic\":\"deadbeef\",\"p2p\":9333,\"rpc\":9332,\"pubval\":48,\"p2shval\":5,\"wifval\":176}"


### PR DESCRIPTION
Looks like ports `7778` were used (leftover from old testnet scripts) for hsukrd & block9 nnops.

Result were the following errors in `addnotary` logging

```
curl: (7) Failed to connect to 127.0.0.1 port 7778: Connection refused
curl: (7) Failed to connect to 127.0.0.1 port 7778: Connection refused
```