### PR TITLE
create json file for valid seed mm2 versions

### DIFF
--- a/doc/seed_version_epochs.json
+++ b/doc/seed_version_epochs.json
@@ -1,0 +1,6 @@
+{
+    "Tracking not yet in effect": {
+      "start": 0,
+      "end": 1938680000
+    }
+}


### PR DESCRIPTION
This file will need to be updated when scoring goes live and whenever an update to the mm2 seed version is announced.
A standard 24hr overlap (i.e. two valid versions for 24hrs period after announcement) is assumed.

ref: https://github.com/KomodoPlatform/atomicDEX-API/issues/654