### PR TITLE
Add 'updatechaintip' API, integrate with iguana_BN_dPoWupdate

### DIFF
--- a/iguana/main.c
+++ b/iguana/main.c
@@ -781,32 +781,18 @@ void jumblr_loop(void *ptr)
 void dpow_loop(void *arg)
 {
     RenameThread("dpow_loop");
-    struct supernet_info *myinfo = arg; double startmilli,endmilli; 
-    int32_t counter = 0;
+    struct supernet_info *myinfo = arg;
     printf("start dpow loop\n");
     while ( 1 )
     {
-        counter++;
-        startmilli = OS_milliseconds();
-        endmilli = startmilli + 1000;
         if ( myinfo->IAMNOTARY != 0 )
         {
-            if ( myinfo->numdpows == 1 )
+            if ( myinfo->numdpows > 0 )
             {
-                iguana_dPoWupdate(myinfo,myinfo->DPOWS[0]);
-                endmilli = startmilli + 100;
-            }
-            else if ( myinfo->numdpows > 1 )
-            {
-                iguana_dPoWupdate(myinfo,myinfo->DPOWS[counter % myinfo->numdpows]);
-                endmilli = startmilli + 20;
-                iguana_dPoWupdate(myinfo,myinfo->DPOWS[0]);
+                dpow_nanomsg_update(myinfo);
             }
         }
-        while ( OS_milliseconds() < endmilli )
-            usleep(1000);
-        if ( counter > myinfo->numdpows+1 )
-            counter = 0;
+        usleep(250000);
     }
 }
 


### PR DESCRIPTION
This hasn't been fully tested since cleaning up for PR. Should be tested prior to merge.

This adds an `updatechaintip` API to iguana's `dpow` agent.  Notarizations **will not occur** without a `blocknotify=` command added to each coin's respective config file.

For main server coins, example below:

```
blocknotify=curl -s --url http://127.0.0.1:7776 --data '{"agent":"dpow","method":"updatechaintip","blockhash":"%s","symbol":"BET"}'
```

For 3P coins:

```
blocknotify=curl -s --url http://127.0.0.1:7779 --data '{"agent":"dpow","method":"updatechaintip","blockhash":"%s","symbol":"VRSC"}'
```