### PR TITLE
change nanomsg headers include(s)

### DIFF
--- a/iguana/exchanges/mm 17740.c
+++ b/iguana/exchanges/mm 17740.c
@@ -59,13 +59,13 @@ void LP_priceupdate(char *base,char *rel,double price,double avebid,double aveas
 	#include "../../crypto777/nanosrc/tcp.h"
 	#include "../../crypto777/nanosrc/pair.h"
 #else
-	#include "/usr/local/include/nanomsg/nn.h"
-	#include "/usr/local/include/nanomsg/bus.h"
-	#include "/usr/local/include/nanomsg/pubsub.h"
-	#include "/usr/local/include/nanomsg/pipeline.h"
-	#include "/usr/local/include/nanomsg/reqrep.h"
-	#include "/usr/local/include/nanomsg/tcp.h"
-	#include "/usr/local/include/nanomsg/pair.h"
+	#include <nanomsg/nn.h>
+	#include <nanomsg/bus.h>
+	#include <nanomsg/pubsub.h>
+	#include <nanomsg/pipeline.h>
+	#include <nanomsg/reqrep.h>
+	#include <nanomsg/tcp.h>
+	#include <nanomsg/pair.h>
 #endif
 #endif
 

--- a/iguana/exchanges/mm.c
+++ b/iguana/exchanges/mm.c
@@ -61,14 +61,14 @@ void LP_priceupdate(char *base,char *rel,double price,double avebid,double aveas
     #include "../../crypto777/nanosrc/pair.h"
     #include "../../crypto777/nanosrc/ws.h"
 #else
-	#include "/usr/local/include/nanomsg/nn.h"
-	#include "/usr/local/include/nanomsg/bus.h"
-	#include "/usr/local/include/nanomsg/pubsub.h"
-	#include "/usr/local/include/nanomsg/pipeline.h"
-	#include "/usr/local/include/nanomsg/reqrep.h"
-	#include "/usr/local/include/nanomsg/tcp.h"
-    #include "/usr/local/include/nanomsg/pair.h"
-    #include "/usr/local/include/nanomsg/ws.h"
+	#include <nanomsg/nn.h>
+	#include <nanomsg/bus.h>
+	#include <nanomsg/pubsub.h>
+	#include <nanomsg/pipeline.h>
+	#include <nanomsg/reqrep.h>
+	#include <nanomsg/tcp.h>
+	#include <nanomsg/pair.h>
+	#include <nanomsg/ws.h>
 #endif
 #endif
 #ifndef NN_WS_MSG_TYPE

--- a/iguana/iguana777.h
+++ b/iguana/iguana777.h
@@ -81,12 +81,12 @@
 #include "../crypto777/nanosrc/reqrep.h"
 #include "../crypto777/nanosrc/tcp.h"
 #else
-#include "/usr/local/include/nanomsg/nn.h"
-#include "/usr/local/include/nanomsg/bus.h"
-#include "/usr/local/include/nanomsg/pubsub.h"
-#include "/usr/local/include/nanomsg/pipeline.h"
-#include "/usr/local/include/nanomsg/reqrep.h"
-#include "/usr/local/include/nanomsg/tcp.h"
+#include <nanomsg/nn.h>
+#include <nanomsg/bus.h>
+#include <nanomsg/pubsub.h>
+#include <nanomsg/pipeline.h>
+#include <nanomsg/reqrep.h>
+#include <nanomsg/tcp.h>
 #endif
 
 struct supernet_info;


### PR DESCRIPTION
format `#include <nanomsg/something.h>` will allow compiler to look into `/usr/inlclude` or `/usr/local/include` as well. So, both variant of nanomsg dependency install will be available:

Variant #1:

```bash
cd ~
git clone https://github.com/nanomsg/nanomsg
cd nanomsg
cmake . -DNN_TESTS=OFF -DNN_ENABLE_DOC=OFF
make -j2
sudo make install
sudo ldconfig
```

Variant #2:

```bash
sudo apt install libnanomsg-dev
```

In both cases iguana will be built correctly.