### PR TITLE
Remove DOC,MARTY. Add BCZERO,MDX,RAPH

### DIFF
--- a/iguana/iguana_notary.c
+++ b/iguana/iguana_notary.c
@@ -559,7 +559,7 @@ STRING_ARG(iguana,addnotary,ipaddr)
 }
 
 // TODO: Confirm that this is the correct list of currencies. Is TOKEL supposed to be in here? It's the only 3rd party coin in the list.
-char NOTARY_CURRENCIES[][65] = { "CCL", "PIRATE", "ILN", "DOC", "THC", "MARTY", "KOIN", "GLEEC", "GLEEC_OLD", "TOKEL", "CLC" };
+char NOTARY_CURRENCIES[][65] = { "CCL", "PIRATE", "ILN", "THC", "MDX", "BCZERO", "RAPH", "KOIN", "GLEEC", "GLEEC_OLD", "TOKEL", "CLC" };
 
 // "LTC", "USD", "EUR", "JPY", "GBP", "AUD", "CAD", "CHF", "NZD", "CNY", "RUB", "MXN", "BRL", "INR", "HKD", "TRY", "ZAR", "PLN", "NOK", "SEK", "DKK", "CZK", "HUF", "ILS", "KRW", "MYR", "PHP", "RON", "SGD", "THB", "BGN", "IDR", "HRK",
 


### PR DESCRIPTION
`NOTARY_CURRENCIES` definition in `dPoW/iguana/iguana_notary.c` has been neglected in the past few `dPoW` updates. 

Not sure if it actually makes a difference. Just know this was traditionally modified in past.